### PR TITLE
Add a random number generator

### DIFF
--- a/random_num_generator.lua
+++ b/random_num_generator.lua
@@ -1,0 +1,31 @@
+RandomNumGenerator = {}
+RandomNumGenerator.__index = RandomNumGenerator
+
+setmetatable(RandomNumGenerator, {
+  __call = function (cls, ...)
+    return cls.new(...)
+  end,
+})
+
+-- Pseudo random numbers generator based on the multiply with carry algorithm
+function RandomNumGenerator.new(seed, carry)
+  local self = setmetatable({}, RandomNumGenerator)
+  -- constants
+  self.a = 1103515245 --from Ansi C
+  self.base = 0x10000  --from Ansi C
+  self.carry = carry or 12345 --from Ansi C
+  self.x = seed % self.base
+  return self
+end
+
+function RandomNumGenerator:clone()
+  return RandomNumGenerator(self.x, self.carry)
+end
+
+-- :gen() returns a random float between 0 and 1. 
+function RandomNumGenerator:gen()
+	local t = self.a * self.x + self.carry
+	self.x = t % self.base
+	self.carry = math.floor(t / self.base)
+	return self.x / self.base
+end


### PR DESCRIPTION
By default lua generates random numbers using math.randomseed() & math.random()

Those two functions
- are side effectful
- don't store their internal state into an object, which means the state is global.
This makes very difficult to test every piece of code using them. This class, although being side effectful, owns its state so that we can instanciate seveal number generators, inject them and mock them for test purposes